### PR TITLE
Default factory public

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Can handle:
 
 You can pass in a `TypeFactory` for creating custom instances like for mocking
 
+You can extend the `DefaultTypeFactory` for creating custom instances while reusing the creation of constructors with single paramter constructors with basic types and empty constructors.
+
+
+```kotlin
+sealed class Fruit {
+  object Orange : Fruit()
+  object Banana : Fruit()
+  data class Apple(color: String) : Fruit()
+}
+
+class FruitTypeFactory : DefaultTypeFactory() {
+    override fun create(what: KClass<*>) = when (what) {
+        Apple::class -> Fruit.Apple(
+            color = "red"
+        )
+        else -> super.create(what)
+    }
+}
+```
 
 Get it:
 

--- a/src/main/kotlin/de/jodamob/junit5/SealedClassesSource.kt
+++ b/src/main/kotlin/de/jodamob/junit5/SealedClassesSource.kt
@@ -38,7 +38,7 @@ annotation class SealedClassesSource(
 }
 
 // default factory that can return singletons and instances of classes with empty constructor
-internal class DefaultTypeFactory: SealedClassesSource.TypeFactory {
+open class DefaultTypeFactory: SealedClassesSource.TypeFactory {
 
     override fun create(what: KClass<*>): Any {
         return what.objectInstance ?: what.constructors.first().create()


### PR DESCRIPTION
Hi @dpreussler ! 👋

I've made the `DefaultTypeFactory` public and open to allow extending it when creating custom factories.

Here it's an usage example:

```kotlin
sealed class Fruit {
  object Orange : Fruit()
  object Banana : Fruit()
  data class Apple(color: String) : Fruit()
}

class FruitTypeFactory : DefaultTypeFactory() {
    override fun create(what: KClass<*>) = when (what) {
        Apple::class -> Fruit.Apple(
            color = "red"
        )
        else -> super.create(what)
    }
}
```

The original issue is here https://github.com/dpreussler/junit5-kotlin/issues/1