### PR TITLE
Support values filtration based on names and mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ class FruitTypeFactory : DefaultTypeFactory() {
 }
 ```
 
+Filter: 
+
+You can filter out a few values by using the names attribute.
+
+```kotlin
+sealed class Family {
+    class Mother: Family()
+    class Father: Family()
+    sealed class Children: Family() {
+        class Son: Children()
+        class Daughter: Children()
+        sealed class GrandChildren: Children() {
+            class GrandSon: GrandChildren()
+            class GradDaughter: GrandChildren()
+        }
+    }
+}
+
+@ParameterizedTest
+@SealedClassesSource(names = ["Mother", "Daughter", "GrandSon"])
+fun test(item: Family)
+```
+Or you can turn this around by setting the mode attribute to EXCLUDE
+
+```kotlin
+@ParameterizedTest
+@SealedClassesSource(names = ["Mother", "Daughter", "GrandSon"], mode = SealedClassesSource.Mode.EXCLUDE)
+fun test(item: Family)
+```
+
 Get it:
 
 ```groovy

--- a/src/test/kotlin/de/jodamob/junit5/SealedClassesSourceTest.kt
+++ b/src/test/kotlin/de/jodamob/junit5/SealedClassesSourceTest.kt
@@ -98,6 +98,45 @@ class SealedClassesSourceTest {
         }
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class Include {
+
+        val items = mutableListOf<String>()
+
+        @AfterAll
+        fun check() {
+            Assertions.assertEquals(listOf("Mother", "Daughter", "GrandSon"), items)
+        }
+
+        @ParameterizedTest
+        @SealedClassesSource(names = ["Mother", "Daughter", "GrandSon"])
+        fun build(member: Family) {
+            items.add(member::class.simpleName!!)
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class Exclude {
+
+        val items = mutableListOf<String>()
+
+        @AfterAll
+        fun check() {
+            Assertions.assertEquals(listOf("Father", "Son", "GradDaughter"), items)
+        }
+
+        @ParameterizedTest
+        @SealedClassesSource(
+            names = ["Mother", "Daughter", "GrandSon"],
+            mode = SealedClassesSource.Mode.EXCLUDE
+        )
+        fun build(member: Family) {
+            items.add(member::class.simpleName!!)
+        }
+    }
+
     @ParameterizedTest
     @SealedClassesSource(factoryClass = CustomFactory::class)
     fun `can check custom types`(item: Custom) {


### PR DESCRIPTION
Hi @dpreussler 

This is proposal to add values filtration based on names and mode in analogue with `EnumSource` annotation.

```
@ParameterizedTest
@SealedClassesSource(names = ["Mother", "Daughter", "GrandSon"])
fun test(item: Family)
```

I think it could be useful.
